### PR TITLE
Fix syntax in EpsilonPlusFlat instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ from zennit.composites import EpsilonPlusFlat
 from zennit.canonizers import SequentialMergeBatchNorm
 
 # define LRP rules and canonizers in zennit
-composite = EpsilonPlusFlat([SequentialMergeBatchNorm()])
+composite = EpsilonPlusFlat(canonizers=[SequentialMergeBatchNorm()])
 
 # load CRP toolbox
 attribution = CondAttribution(model)

--- a/tutorials/attributions.ipynb
+++ b/tutorials/attributions.ipynb
@@ -261,7 +261,7 @@
     "from zennit.canonizers import SequentialMergeBatchNorm\n",
     "from crp.attribution import CondAttribution\n",
     "\n",
-    "composite = EpsilonPlusFlat([SequentialMergeBatchNorm()])\n",
+    "composite = EpsilonPlusFlat(canonizers=[SequentialMergeBatchNorm()])\n",
     "attribution = CondAttribution(model, no_param_grad=True)"
    ]
   },

--- a/tutorials/feature_visualization.ipynb
+++ b/tutorials/feature_visualization.ipynb
@@ -70,7 +70,7 @@
     "model.eval()\n",
     "\n",
     "canonizers = [SequentialMergeBatchNorm()]\n",
-    "composite = EpsilonPlusFlat(canonizers)\n",
+    "composite = EpsilonPlusFlat(canonizers=canonizers)\n",
     "\n",
     "image = Image.open(\"images/lizard.jpg\")\n",
     "image"


### PR DESCRIPTION
There is a mismatch between the current implementation of composites here and in the Zennit core library. In two tutorial notebooks and in the README file, the `EpsilonPlusFlat` class is instantiated with incorrect arguments, which causes an error. This issue arises from passing the list of canonizers as a positional argument, whereas the source code clearly indicates it should be passed as a named argument.

I have fixed this issue in both notebooks and in the README.

Below is an actual example from the `attribution.ipynb` notebook.
```python
from zennit.composites import EpsilonPlusFlat
from zennit.canonizers import SequentialMergeBatchNorm
from crp.attribution import CondAttribution

composite = EpsilonPlusFlat([SequentialMergeBatchNorm()])
attribution = CondAttribution(model, no_param_grad=True)
```
Output:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[16], [line 5](vscode-notebook-cell:?execution_count=16&line=5)
      [2](vscode-notebook-cell:?execution_count=16&line=2) from zennit.canonizers import SequentialMergeBatchNorm
      [3](vscode-notebook-cell:?execution_count=16&line=3) from crp.attribution import CondAttribution
----> [5](vscode-notebook-cell:?execution_count=16&line=5) composite = EpsilonPlusFlat([SequentialMergeBatchNorm()])
      [6](vscode-notebook-cell:?execution_count=16&line=6) attribution = CondAttribution(model, no_param_grad=True)

File ~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:425, in EpsilonPlusFlat.__init__(self, epsilon, stabilizer, layer_map, first_map, zero_params, canonizers)
    [420](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:420)     first_map = []
    [422](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:422) rule_kwargs = {'zero_params': zero_params}
    [423](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:423) layer_map = layer_map + layer_map_base(stabilizer) + [
    [424](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:424)     (Convolution, ZPlus(stabilizer=stabilizer, **rule_kwargs)),
--> [425](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:425)     (torch.nn.Linear, Epsilon(epsilon=epsilon, **rule_kwargs)),
    [426](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:426) ]
    [427](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:427) first_map = first_map + [
    [428](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:428)     (Linear, Flat(stabilizer=stabilizer, **rule_kwargs))
    [429](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:429) ]
    [430](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/composites.py:430) super().__init__(layer_map=layer_map, first_map=first_map, canonizers=canonizers)

File ~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:115, in Epsilon.__init__(self, epsilon, zero_params)
    [114](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:114) def __init__(self, epsilon=1e-6, zero_params=None):
--> [115](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:115)     stabilizer_fn = Stabilizer.ensure(epsilon)
    [116](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:116)     super().__init__(
    [117](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:117)         input_modifiers=[lambda input: input],
    [118](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:118)         param_modifiers=[NoMod(zero_params=zero_params)],
   (...)
    [121](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:121)         reducer=(lambda inputs, gradients: inputs[0] * gradients[0]),
    [122](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/rules.py:122)     )

File ~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/core.py:91, in Stabilizer.ensure(cls, value)
     [89](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/core.py:89) if callable(value):
     [90](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/core.py:90)     return value
---> [91](https://file+.vscode-resource.vscode-cdn.net/home/ignacy/putai/thesis/forkzennit/zennit-crp/tutorials/~/miniconda3/envs/lrp/lib/python3.12/site-packages/zennit/core.py:91) raise TypeError(f'Value {value} is not a valid stabilizer!')

TypeError: Value [<zennit.canonizers.SequentialMergeBatchNorm object at 0x7d0a5bd9bfe0>] is not a valid stabilizer!
```